### PR TITLE
Make PipeWire socket read-only

### DIFF
--- a/org.jacktrip.JackTrip.json
+++ b/org.jacktrip.JackTrip.json
@@ -12,7 +12,7 @@
 		"--socket=fallback-x11",
 		"--device=dri",
 		"--share=network",
-		"--filesystem=xdg-run/pipewire-0",
+		"--filesystem=xdg-run/pipewire-0:ro",
 		"--env=PIPEWIRE_LATENCY=128/48000",
 		"--env=QML_IMPORT_PATH=/app/qml",
 		"--env=QT_QUICK_CONTROLS_STYLE=universal"


### PR DESCRIPTION
Flatpaks should not have write access to socket files, like `xdg-run/pipewire-0`. Bidirectional communication is possible regardless of the suffix, so a benevolent app sees no difference. While it shouldn't be possible in theory, it would be best to prevent the possibility of deleting or modifying the socket itself. Flathub maintainers typically request this for new submissions.

https://discourse.flathub.org/t/what-is-the-difference-if-the-pipewire-socket-is-read-only/11951/7